### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Install from [CRAN](https://cran.r-project.org/web/packages/RcppML/index.html) o
 
 ```
 install.packages('RcppML')                       # install CRAN version
+devtools::install_github("zdebruine/RcppSparse") # dependency for RcppML
 devtools::install_github("zdebruine/RcppML")     # compile dev version
 ```
 


### PR DESCRIPTION
Install RcppSparse before attempting to install RcppML (which will otherwise fail). 

It may be preferable to use `BiocManager::install()` since this will automate installation of any BioC dependencies as well.