### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,6 @@ Imports:
     Rcpp, 
     Matrix,
     RcppEigen,
-    RcppSparse,
     methods,
     stats,
     ggplot2,
@@ -22,8 +21,7 @@ Imports:
     utils
 LinkingTo: 
     Rcpp, 
-    RcppEigen,
-    RcppSparse
+    RcppEigen
 VignetteBuilder: knitr
 RoxygenNote: 7.1.2
 Suggests: 


### PR DESCRIPTION
Per #32 , if RcppSparse is neither required nor linked to, it must be removed from Imports and LinkingTo, else installation of RcppML will fail in the absence of RcppSparse.