### PR TITLE
Make crossValidate compatible with large matrices

### DIFF
--- a/R/crossValidate.R
+++ b/R/crossValidate.R
@@ -39,7 +39,7 @@ crossValidate <- function(data, k, reps = 3, n = 0.05, verbose = FALSE, ...) {
     
     # get samples, features, or missing values for test/training/cross-validation
     if(!is.null(p$seed)) set.seed(p$seed + rep)
-    mask_matrix <- rsparsematrix(nrow(data), ncol(data), n, rand.x = NULL)
+    mask_matrix <- rsparsematrix(as.numeric(nrow(data)), as.numeric(ncol(data)), n, rand.x = NULL)
 
     for(rank in k){
       if(verbose) cat(rank, " ")


### PR DESCRIPTION
Fixes the bug that when nrow(data) * ncol(data) > .Machine$integer.max, crossValidate() gives the error "(nnz <- as.integer(nnz)) >= 0 is not TRUE".